### PR TITLE
Fix Fishing and Hunting by increasing days-ahead to 7

### DIFF
--- a/config/channels.yaml
+++ b/config/channels.yaml
@@ -3177,6 +3177,7 @@
 - id: fishingandhunting.tv
   enabled: true
   name: Fishing and Hunting
+  days-ahead: 7
   groups: ["tivi.bg", "vivacom", "а1"]
   sources:
   - tv-programa.bg


### PR DESCRIPTION
We need 7 days-ahead for tv-programa.bg to work correctly